### PR TITLE
Fix syntax in docker-compose-mainnet.yml

### DIFF
--- a/docker-compose-mainnet.yml
+++ b/docker-compose-mainnet.yml
@@ -47,7 +47,7 @@ services:
       EMERGENCY_FORK_NUMBER: 750000
     volumes:
       - $PWD/chaindata/l2geth:/root/.ethereum
-      - $PWD/geth.sh:/geth.sh
+      - $PWD/geth.sh:/.geth.sh
     expose:
       - 8545
     ports:


### PR DESCRIPTION
Otherwise I was getting this:
```
~/metis-replica-node-guide $ sudo docker-compose up -d l2geth
WARN[0000] The "PWD" variable is not set. Defaulting to a blank string. 
WARN[0000] The "PWD" variable is not set. Defaulting to a blank string. 
WARN[0000] The "PWD" variable is not set. Defaulting to a blank string. 
[+] Running 0/1
 ⠿ Container metis-replica-node-guide-l2geth-1  Starting                                                                       0.5s
Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/geth.sh" to rootfs at "/geth.sh": mount /geth.sh:/geth.sh (via /proc/self/fd/6), flags: 0x5000: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type```